### PR TITLE
Do not needlessy loop all clients

### DIFF
--- a/z21.cpp
+++ b/z21.cpp
@@ -256,10 +256,12 @@ void z21Class::receive(uint8_t client, uint8_t *packet)
 			//Check if Broadcast Flag is correct set up?
 			bool BCset = true;
 			for (byte i = 0; i < z21clientMAX; i++) {
-				if (ActIP[i].client == client && ActIP[i].BCFlag == 0) {
-					BCset = false;
-					break;
+			  if (ActIP[i].client == client) {
+			        if (ActIP[i].BCFlag == 0) {
+				  BCset = false;
 				}
+				break;
+			  }
 			}
 			//Fall to next if no BCFlag is set!
 			if (BCset)


### PR DESCRIPTION
Hello,
Congratulations on the work you've done!

While testing this library in [Z21ServerEmulator](https://github.com/gfgit/Z21ServerEmulator) I've found this loop and the condition seems not correct.
If the BC flag is not zero, it keeps iterating but it will not match any other client because they are unique.

I've tried to keep indentation consistent with the rest of the source code.

Filippo