### PR TITLE
Use 0b for binary literals

### DIFF
--- a/z21.cpp
+++ b/z21.cpp
@@ -188,7 +188,7 @@ void z21Class::receive(uint8_t client, uint8_t *packet)
 			}
 			break;
 		  case LAN_X_CV_POM: {	//X-Header = 0xE6
-		    uint16_t CVAdr = ((packet[8] & B11) << 8) + packet[9];
+			uint16_t CVAdr = ((packet[8] & 0b11) << 8) + packet[9];
 			byte value = packet[10];
 			if (packet[5] == 0x30) {  //DB0 = LAN_X_CV_POM
 			  uint16_t Adr = ((packet[6] & 0x3F) << 8) + packet[7];
@@ -341,7 +341,7 @@ void z21Class::receive(uint8_t client, uint8_t *packet)
 			else if (packet[5] == LAN_X_SET_LOCO_FUNCTION) {  //DB0 = 0xF8
 			  //LAN_X_SET_LOCO_FUNCTION  Adr_MSB        Adr_LSB            Type (00=AUS/01=EIN/10=UM)      Funktion
 			  if (notifyz21LocoFkt)
-				notifyz21LocoFkt(word(packet[6] & 0x3F, packet[7]), packet[8] >> 6, packet[8] & B00111111); 
+				notifyz21LocoFkt(word(packet[6] & 0x3F, packet[7]), packet[8] >> 6, packet[8] & 0b00111111);
 			  //uint16_t Adr, uint8_t type, uint8_t fkt
 			}
 			//LAN_X_SET_LOCO_FUNCTION_GROUP:
@@ -895,7 +895,7 @@ void z21Class::returnLocoStateFull (byte client, uint16_t Adr, bool bc)
 		}
 		else { //Info to client that ask:
 			if (ActIP[i].adr == Adr) {
-				data[3] = data[3] & B111;	//clear busy flag!
+				data[3] = data[3] & 0b111;	//clear busy flag!
 			}
 			EthSend (client, 15, LAN_X_Header, data, true, Z21bcNone);  //Send Loco status und Funktions to request App
 			data[3] = data[3] | 0x08; //BUSY!

--- a/z21header.h
+++ b/z21header.h
@@ -78,36 +78,36 @@
 
 //**************************************************************
 //Z21 BC Flags
-#define Z21bcNone                B00000000
+#define Z21bcNone                0b00000000
 #define Z21bcAll    		0x00000001
-#define Z21bcAll_s               B00000001
+#define Z21bcAll_s               0b00000001
 #define Z21bcRBus   		0x00000002
-#define Z21bcRBus_s              B00000010
+#define Z21bcRBus_s              0b00000010
 #define Z21bcRailcom    	0x00000004    //RailCom-Daten für Abo Loks
 #define Z21bcRailcom_s			0x100
 
 #define Z21bcSystemInfo 	0x00000100	//LAN_SYSTEMSTATE_DATACHANGED
-#define Z21bcSystemInfo_s        B00000100
+#define Z21bcSystemInfo_s        0b00000100
 
 //ab FW Version 1.20:
 #define Z21bcNetAll          0x00010000 // Alles, auch alle Loks ohne vorher die Lokadresse abonnieren zu müssen (für PC Steuerung)
-#define Z21bcNetAll_s            B00001000
+#define Z21bcNetAll_s            0b00001000
 
 #define Z21bcLocoNet         0x01000000 // LocoNet Meldungen an LAN Client weiterleiten (ohne Loks und Weichen)
-#define Z21bcLocoNet_s           B00010000
+#define Z21bcLocoNet_s           0b00010000
 #define Z21bcLocoNetLocos    0x02000000 // Lok-spezifische LocoNet Meldungen an LAN Client weiterleiten
-#define Z21bcLocoNetLocos_s      B00110000
+#define Z21bcLocoNetLocos_s      0b00110000
 #define Z21bcLocoNetSwitches 0x04000000 // Weichen-spezifische LocoNet Meldungen an LAN Client weiterleiten
-#define Z21bcLocoNetSwitches_s   B01010000
+#define Z21bcLocoNetSwitches_s   0b01010000
 
 //ab FW Version 1.22:
 #define Z21bcLocoNetGBM      0x08000000  //Status-Meldungen von Gleisbesetztmeldern am LocoNet-Bus
-#define Z21bcLocoNetGBM_s        B10010000
+#define Z21bcLocoNetGBM_s        0b10010000
 
 //ab FW Version 1.29:
 #define Z21bcRailComAll		 0x00040000 //alles: Änderungen bei RailCom-Daten ohne Lok Abo! -> LAN_RAILCOM_DATACHANGED
-#define Z21bcRailComAll_s		 B10000000
+#define Z21bcRailComAll_s		 0b10000000
 
 //ab FW Version 1.30:
 #define Z21bcCANDetector	 0x00080000	//Meldungen vom Gelisbesetztmeldern am CAN-Bus
-#define Z21bcCANDetector_s		 B11000000
+#define Z21bcCANDetector_s		 0b11000000


### PR DESCRIPTION
Hello,
I'm getting error building this code with GCC 12.2.0.
This is because `B0001` literals are non standard and are supported only by Arduino compiler
I've changed to using `0b0001` literals which compile correctly.
This seems supported also on Arduino: https://www.arduino.cc/reference/en/language/variables/constants/integerconstants/